### PR TITLE
Potentially fix XSS bug (#28)

### DIFF
--- a/client/helpers/handlebars.js
+++ b/client/helpers/handlebars.js
@@ -7,6 +7,7 @@ Handlebars.registerHelper('loggedIn', function () {
 });
 
 Handlebars.registerHelper('breaklines', function (text) {
+  text = Handlebars.Utils.escapeExpression(text);
   text = text.replace(/(\r\n|\n|\r)/gm, '<br>');
   return new Handlebars.SafeString(text);
 });


### PR DESCRIPTION
Escape text before adding line breaks. I'm not sure if this is redundant and removes all line breaks anyway though.

Fixes #28 